### PR TITLE
Changed `WateringPatcher` `performToolAction` prefix to be passthrough

### DIFF
--- a/AchtuurCore/Events/WateringPatcher.cs
+++ b/AchtuurCore/Events/WateringPatcher.cs
@@ -34,7 +34,7 @@ namespace AchtuurCore.Events
         // performToolAction called on HoeDirt with Tool = watering can
         // If HoeDirt.state.Value changed to 1 -> soil has been watered
 
-        private static bool prefix_performToolAction(Tool t, HoeDirt __instance, out WateringInfo __state)
+        private static void prefix_performToolAction(Tool t, HoeDirt __instance, out WateringInfo __state)
         {
             __state = new WateringInfo();
             try
@@ -46,8 +46,6 @@ namespace AchtuurCore.Events
             {
                 ModEntry.Instance.Monitor.Log($"Something went wrong when prefix patching performToolAction (WateringPatcher):\n{e}", LogLevel.Error);
             }
-            return true; //Always run original function
-            
         }
 
         private static void postfix_performToolAction(ref HoeDirt __instance, WateringInfo __state)


### PR DESCRIPTION
Since your prefix never makes the original method not run, it should be a passthrough prefix, otherwise it may be skipped if another prefix (most likely from another mod) chooses to skip the original method.

Quote from Harmony's documentation (https://harmony.pardeike.net/articles/patching-prefix.html):
> The first prefix that returns false will skip all remaining prefixes unless they have no side effects (no return value, no ref arguments) and will skip the original too. Postfixes and Finalizers are not affected.