### PR TITLE
Add required string ID to particle lightsource

### DIFF
--- a/AchtuurCore/AchtuurCore.csproj
+++ b/AchtuurCore/AchtuurCore.csproj
@@ -13,4 +13,6 @@
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.0" />
   </ItemGroup>
 
+  <ProjectExtensions><VisualStudio><UserProperties manifest_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+
 </Project>

--- a/AchtuurCore/Framework/Particle/Particle.cs
+++ b/AchtuurCore/Framework/Particle/Particle.cs
@@ -59,7 +59,7 @@ public class Particle : ICloneable
         if (Context.IsWorldReady)
             id = Game1.player.UniqueMultiplayerID;
 
-        lightSource = new LightSource(10, Vector2.Zero, this.size.LengthSquared() * lightRadius, this.color, LightSource.LightContext.None, id);
+        lightSource = new LightSource("particleLight", 10, Vector2.Zero, this.size.LengthSquared() * lightRadius, this.color, LightSource.LightContext.None, id);
     }
 
     public void AddState<S>(S state)

--- a/AchtuurCore/manifest.json
+++ b/AchtuurCore/manifest.json
@@ -1,13 +1,11 @@
 {
-    "Name": "AchtuurCore",
-    "Author": "Achtuur",
-    "Version": "1.3.0",
-    "Description": "Core mod for most of my mods.",
-    "UniqueID": "Achtuur.AchtuurCore",
-    "EntryDll": "AchtuurCore.dll",
-    "MinimumApiVersion": "4.0.0",
-    "dependencies": [
-     
-    ],
-    "UpdateKeys": [ "Nexus:16827" ]
+  "$schema": "https://smapi.io/schemas/manifest.json",
+  "Name": "AchtuurCore",
+  "Author": "Achtuur",
+  "Version": "1.3.1",
+  "Description": "Core mod for most of my mods.",
+  "UniqueID": "Achtuur.AchtuurCore",
+  "EntryDll": "AchtuurCore.dll",
+  "MinimumApiVersion": "4.1.0-beta",
+  "UpdateKeys": [ "Nexus:16827" ]
 }


### PR DESCRIPTION
LightSource has a new required string ID, it needs to be globally unique and SMAPI doesn't handle that for you, I am really unsure when this light source is even being used so I don't really know how to proceed with handling it. This does fix the mod not working in the beta at all but I have a feeling it might not work for the debug aspect, though I'm unsure how to test that.